### PR TITLE
Added TASKCFG_ALL_BROKER_DISK_TYPE

### DIFF
--- a/frameworks/kafka/universe/marathon.json.mustache
+++ b/frameworks/kafka/universe/marathon.json.mustache
@@ -66,6 +66,7 @@
 
 
     "TASKCFG_ALL_BROKER_DISK_PATH" : "{{brokers.disk_path}}",
+    "TASKCFG_ALL_BROKER_DISK_TYPE" : "{{brokers.disk_type}}",
     "TASKCFG_ALL_BROKER_DISKS" : "{{brokers.disks}}",
     "TASKCFG_ALL_PARSE_DISKS_INPUT_VAR": "BROKER_DISKS", 
     "TASKCFG_ALL_PARSE_DISKS_OUTPUT_VAR": "broker_disks", 


### PR DESCRIPTION
@adragomir thanks for this. 
I've tested your changes on a DC/OS 1.10 cluster and noticed this config was missing.